### PR TITLE
Fix citation for vfnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@
 
 ## summary
 
-small-object-detection benchmark on visdrone and xview datasets using [fcos](https://arxiv.org/abs/1904.01355), [vfnet](https://arxiv.org/abs/1810.05943) and [tood](https://arxiv.org/abs/2108.07755) detectors
+
+
+small-object-detection benchmark on visdrone and xview datasets using [fcos](https://arxiv.org/abs/1904.01355), [vfnet](https://arxiv.org/abs/2008.13367) and [tood](https://arxiv.org/abs/2108.07755) detectors
 
 refer to [Slicing Aided Hyper Inference and Fine-tuning for Small Object Detection](https://ieeexplore.ieee.org/document/9897990) for full technical analysis
 


### PR DESCRIPTION
There are two VarifocalNet and `README.md` seems to wrongly distinguish these two.

The object detection one is *Varifocalnet: An iou-aware dense object detector* 
and the other one is *Varifocal-net: A chromosome classification approach using deep convolutional networks*